### PR TITLE
Remove commit_reveal_weights_interval and add commit_reveal_weights_p…

### DIFF
--- a/bt_decode.pyi
+++ b/bt_decode.pyi
@@ -227,7 +227,7 @@ class SubnetHyperparameters:
     max_validators: int
     adjustment_alpha: int
     difficulty: int
-    commit_reveal_weights_periods: int
+    commit_reveal_periods: int
     commit_reveal_weights_enabled: bool
     alpha_high: int
     alpha_low: int

--- a/bt_decode.pyi
+++ b/bt_decode.pyi
@@ -227,7 +227,7 @@ class SubnetHyperparameters:
     max_validators: int
     adjustment_alpha: int
     difficulty: int
-    commit_reveal_weights_interval: int
+    commit_reveal_weights_periods: int
     commit_reveal_weights_enabled: bool
     alpha_high: int
     alpha_low: int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ mod bt_decode {
         max_validators: Compact<u16>,
         adjustment_alpha: Compact<u64>,
         difficulty: Compact<u64>,
-        commit_reveal_weights_periods: Compact<u64>,
+        commit_reveal_periods: Compact<u64>,
         commit_reveal_weights_enabled: bool,
         alpha_high: Compact<u16>,
         alpha_low: Compact<u16>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ mod bt_decode {
         max_validators: Compact<u16>,
         adjustment_alpha: Compact<u64>,
         difficulty: Compact<u64>,
-        commit_reveal_weights_interval: Compact<u64>,
+        commit_reveal_weights_periods: Compact<u64>,
         commit_reveal_weights_enabled: bool,
         alpha_high: Compact<u16>,
         alpha_low: Compact<u16>,

--- a/tests/test_types.json
+++ b/tests/test_types.json
@@ -15547,7 +15547,7 @@
                                 ]
                             },
                             {
-                                "name": "sudo_set_commit_reveal_weights_interval",
+                                "name": "sudo_set_commit_reveal_weights_periods",
                                 "fields": [
                                     {
                                         "name": "netuid",

--- a/tests/test_types.json
+++ b/tests/test_types.json
@@ -15562,7 +15562,7 @@
                                 ],
                                 "index": 48,
                                 "docs": [
-                                    "The extrinsic sets the commit/reveal interval for a subnet.",
+                                    "The extrinsic sets the commit/reveal period for a subnet.",
                                     "It is only callable by the root account or subnet owner.",
                                     "The extrinsic will call the Subtensor pallet to set the interval."
                                 ]


### PR DESCRIPTION
…eriods

This change updates variable names in multiple files for consistency and clarity. The renamed variables reflect the intended meaning more accurately across the codebase and tests.