### PR TITLE
Feat/all grab registry as dict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,13 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bt_decode"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "custom_derive",
  "frame-metadata 16.0.0",
  "parity-scale-codec",
  "pyo3",
+ "pythonize",
  "scale-bits 0.4.0",
  "scale-decode",
  "scale-info",
@@ -277,6 +278,16 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn 2.0.76",
+]
+
+[[package]]
+name = "pythonize"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcf491425978bd889015d5430f6473d91bdfa2097262f1e731aadcf6c2113e"
+dependencies = [
+ "pyo3",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bt_decode"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 [lib]
@@ -30,3 +30,4 @@ scale-info = { version = "2.11.2", features = [ "serde" ], default-features = fa
 serde_json = { version = "1.0.127", features = [ "alloc" ], default-features = false }
 scale-bits = { version = "0.4.0", default-features = false }
 scale-value = { version = "0.16.2", default-features = false }
+pythonize = "0.22.0"

--- a/bt_decode.pyi
+++ b/bt_decode.pyi
@@ -69,12 +69,8 @@ class NeuronInfo:
     dividends: int
     last_update: int
     validator_permit: bool
-    weights: List[
-        Tuple[int, int]  # Vec of (uid, weight)
-    ]
-    bonds: List[
-        Tuple[int, int]  # Vec of (uid, bond)
-    ]
+    weights: List[Tuple[int, int]]  # Vec of (uid, weight)
+    bonds: List[Tuple[int, int]]  # Vec of (uid, bond)
     pruning_score: int
 
     @staticmethod

--- a/bt_decode.pyi
+++ b/bt_decode.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 class AxonInfo:
     #  Axon serving block.
@@ -315,6 +315,8 @@ class MetadataV15:
         """
         Returns a JSON representation of the metadata.
         """
+        pass
+    def value(self) -> Dict[str, Any]:
         pass
 
 class PortableRegistry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bt-decode"
-version = "0.2.1a"
+version = "0.3.0a"
 description = "A wrapper around the scale-codec crate for fast scale-decoding of Bittensor data structures."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,12 @@ mod bt_decode {
                 _ => panic!("Invalid metadata version"),
             }
         }
+
+        #[pyo3(name = "value")]
+        fn value(&self, py: Python) -> PyResult<Py<PyAny>> {
+            let dict = pythonize::pythonize(py, &self.metadata)?;
+            Ok(dict.into())
+        }
     }
 
     #[pyclass(name = "PortableRegistry")]


### PR DESCRIPTION
Adds the ability to grab the Metadata V15 object via 
```python
MetadataV15.value() -> Dict[str, Any]:
```