### PR TITLE
add some logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,8 +26,10 @@ version = "0.5.0-a0"
 dependencies = [
  "custom_derive",
  "frame-metadata 16.0.0",
+ "log",
  "parity-scale-codec",
  "pyo3",
+ "pyo3-log",
  "pythonize",
  "scale-bits 0.4.0",
  "scale-decode",
@@ -149,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +267,17 @@ checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5bb22b77965a7b5394e9aae9897a0607b51df5167561ffc3b02643b4200bc7"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ serde_json = { version = "1.0.127", features = [ "alloc" ], default-features = f
 scale-bits = { version = "0.4.0", default-features = false }
 scale-value = { version = "0.16.2", default-features = false }
 pythonize = "0.23.0"
+log = { version = "0.4.25", default-features = false }
+pyo3-log = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
Adds some logging and passes to the python via the `pyo3-log` crate.   
[Requires us to setup the logging](https://pyo3.rs/v0.23.2/ecosystem/logging.html#using-pyo3-log-to-send-rust-log-messages-to-python) with`logging` before import of `bt_decode`:  
E.g.:
```python
import logging

FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
logging.basicConfig(format=FORMAT)
logging.getLogger("btdecode").setLevel(logging.DEBUG)

import bt_decode
```