### PR TITLE
Removes the AccountId decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,35 +21,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bt_decode"
 version = "0.7.0"
 dependencies = [
- "base58",
- "blake2",
  "custom_derive",
  "frame-metadata 16.0.0",
  "log",
@@ -77,16 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "custom_derive"
 version = "0.2.0"
 dependencies = [
@@ -104,17 +68,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -150,16 +103,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -525,12 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,12 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,12 +523,6 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,3 @@ scale-value = { version = "0.16.2", default-features = false }
 pythonize = "0.23.0"
 log = { version = "0.4.25", default-features = false }
 pyo3-log = { version = "0.12.1", default-features = false }
-blake2 = "0.10"
-base58 = "0.2"

--- a/bt_decode.pyi
+++ b/bt_decode.pyi
@@ -346,10 +346,7 @@ class PortableRegistry:
         pass
 
 def decode(
-    type_string: str,
-    portable_registry: PortableRegistry,
-    encoded: bytes,
-    legacy_account_id: bool = True,
+    type_string: str, portable_registry: PortableRegistry, encoded: bytes
 ) -> Any:
     pass
 
@@ -357,7 +354,6 @@ def decode_list(
     list_type_strings: list[str],
     portable_registry: PortableRegistry,
     list_encoded: list[bytes],
-    legacy_account_id: bool = True,
 ) -> list[Any]:
     """
     Decode a list of SCALE-encoded types using a list of their type-strings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ mod dyndecoder;
 mod bt_decode {
     use std::collections::HashMap;
 
-    use base58::ToBase58;
-    use blake2::{Blake2b512, Digest};
     use dyndecoder::{fill_memo_using_well_known_types, get_type_id_from_type_string};
     use frame_metadata::v15::RuntimeMetadataV15;
     use pyo3::types::{PyDict, PyInt, PyList, PyTuple};
@@ -45,25 +43,6 @@ mod bt_decode {
     };
 
     use super::*;
-
-    fn account_id_to_ss58(account_id: [u8; 32], ss58_prefix: u16) -> String {
-        let mut data = Vec::with_capacity(35);
-        match ss58_prefix {
-            0..=63 => data.push(ss58_prefix as u8),
-            64..=16383 => {
-                data.push(((ss58_prefix & 0b0011_1111) | 0b0100_0000) as u8);
-                data.push((ss58_prefix >> 6) as u8);
-            }
-            _ => panic!("Invalid SS58 prefix"),
-        }
-        data.extend(account_id);
-        let checksum = Blake2b512::new()
-            .chain_update(b"SS58PRE")
-            .chain_update(&data)
-            .finalize();
-        data.extend_from_slice(&checksum[..2]);
-        data.to_base58()
-    }
 
     #[pyclass(name = "AxonInfo", get_all)]
     #[derive(Clone, Encode, Decode)]
@@ -390,40 +369,32 @@ mod bt_decode {
         }
     }
 
-    fn composite_to_py_object(
-        py: Python,
-        value: Composite<u32>,
-        legacy_account_id: bool,
-    ) -> PyResult<Py<PyAny>> {
+    fn composite_to_py_object(py: Python, value: Composite<u32>) -> PyResult<Py<PyAny>> {
         match value {
             Composite::Named(inner_) => {
                 let dict = PyDict::new_bound(py);
                 for (key, val) in inner_.iter() {
-                    let val_py = value_to_pyobject(py, val.clone(), legacy_account_id)?;
+                    let val_py = value_to_pyobject(py, val.clone())?;
                     dict.set_item(key, val_py)?;
                 }
+
                 Ok(dict.to_object(py))
             }
             Composite::Unnamed(inner_) => {
-                let items: Vec<Py<PyAny>> = inner_
-                    .iter()
-                    .map(|val| value_to_pyobject(py, val.clone(), legacy_account_id))
-                    .collect::<PyResult<Vec<Py<PyAny>>>>()?;
-                if !legacy_account_id && inner_.len() == 1 && inner_[0].context == 1 {
-                    // AccountIds are the only ones with context of 1, this will cause them to not be placed in a tuple
-                    return Ok(items[0].clone_ref(py));
-                }
-                let tuple = PyTuple::new_bound(py, items);
+                let tuple = PyTuple::new_bound(
+                    py,
+                    inner_
+                        .iter()
+                        .map(|val| value_to_pyobject(py, val.clone()))
+                        .collect::<PyResult<Vec<Py<PyAny>>>>()?,
+                );
+
                 Ok(tuple.to_object(py))
             }
         }
     }
 
-    fn value_to_pyobject(
-        py: Python,
-        value: Value<u32>,
-        legacy_account_id: bool,
-    ) -> PyResult<Py<PyAny>> {
+    fn value_to_pyobject(py: Python, value: Value<u32>) -> PyResult<Py<PyAny>> {
         match value.value {
             ValueDef::<u32>::Primitive(inner) => {
                 let value = match inner {
@@ -443,58 +414,17 @@ mod bt_decode {
 
                 Ok(value)
             }
-            ValueDef::<u32>::Composite(composite) => {
-                if legacy_account_id {
-                    let value = composite_to_py_object(py, composite, legacy_account_id)?;
-                    return Ok(value);
-                } else {
-                    match &composite {
-                        Composite::Unnamed(ref inner) if inner.len() == 32 => {
-                            let mut account_id_bytes: Vec<u8> = Vec::with_capacity(32);
+            ValueDef::<u32>::Composite(inner) => {
+                let value = composite_to_py_object(py, inner)?;
 
-                            for val in inner.iter() {
-                                match val.value {
-                                    ValueDef::<u32>::Primitive(Primitive::U128(byte)) => {
-                                        account_id_bytes.push(byte as u8);
-                                    }
-                                    _ => {
-                                        let value = composite_to_py_object(
-                                            py,
-                                            composite,
-                                            legacy_account_id,
-                                        )?;
-                                        return Ok(value);
-                                    }
-                                }
-                            }
-
-                            let account_id_array: [u8; 32] =
-                                account_id_bytes.try_into().map_err(|_| {
-                                    PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                                        "Invalid AccountId length",
-                                    )
-                                })?;
-
-                            let ss58_address = account_id_to_ss58(account_id_array, 42);
-                            Ok(ss58_address.as_str().to_object(py))
-                        }
-                        _ => {
-                            let value = composite_to_py_object(py, composite, legacy_account_id)?;
-                            Ok(value)
-                        }
-                    }
-                }
+                Ok(value)
             }
             ValueDef::<u32>::Variant(inner) => {
                 if inner.name == "None" || inner.name == "Some" {
                     match inner.name.as_str() {
                         "None" => Ok(py.None()),
                         "Some" => {
-                            let some = composite_to_py_object(
-                                py,
-                                inner.values.clone(),
-                                legacy_account_id,
-                            )?;
+                            let some = composite_to_py_object(py, inner.values.clone())?;
                             if inner.values.len() == 1 {
                                 let tuple = some
                                     .downcast_bound::<PyTuple>(py)
@@ -516,7 +446,7 @@ mod bt_decode {
                     let value = PyDict::new_bound(py);
                     value.set_item(
                         inner.name.clone(),
-                        composite_to_py_object(py, inner.values, legacy_account_id)?,
+                        composite_to_py_object(py, inner.values)?,
                     )?;
 
                     Ok(value.to_object(py))
@@ -1100,13 +1030,12 @@ mod bt_decode {
         pyobject_to_value_no_option_check(py, to_encode, ty, type_id, portable_registry)
     }
 
-    #[pyfunction(name = "decode", signature = (type_string, portable_registry, encoded, legacy_account_id=true))]
+    #[pyfunction(name = "decode")]
     fn py_decode(
         py: Python,
         type_string: &str,
         portable_registry: &PyPortableRegistry,
         encoded: &[u8],
-        legacy_account_id: bool,
     ) -> PyResult<Py<PyAny>> {
         // Create a memoization table for the type string to type id conversion
         let mut memo = HashMap::<String, u32>::new();
@@ -1128,16 +1057,15 @@ mod bt_decode {
             ))
         })?;
 
-        value_to_pyobject(py, decoded, legacy_account_id)
+        value_to_pyobject(py, decoded)
     }
 
-    #[pyfunction(name = "decode_list", signature = (list_type_strings, portable_registry, list_encoded, legacy_account_id=true))]
+    #[pyfunction(name = "decode_list")]
     fn py_decode_list(
         py: Python,
         list_type_strings: Vec<String>,
         portable_registry: &PyPortableRegistry,
         list_encoded: Vec<Vec<u8>>,
-        legacy_account_id: bool,
     ) -> PyResult<Vec<Py<PyAny>>> {
         // Create a memoization table for the type string to type id conversion
         let mut memo = HashMap::<String, u32>::new();
@@ -1165,7 +1093,7 @@ mod bt_decode {
                     ))
                 })?;
 
-            decoded_list.push(value_to_pyobject(py, decoded, legacy_account_id)?);
+            decoded_list.push(value_to_pyobject(py, decoded)?);
         }
 
         Ok(decoded_list)


### PR DESCRIPTION
Removes the AccountId decoding used in #22 and #25, as the AccountId decoding will now be handled in Python (https://github.com/opentensor/async-substrate-interface/pull/143)